### PR TITLE
📝 Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ You can download the latest executable version of this project in the [Releases 
 ### Tech Stack
 - GitModules
 - React
-- Zustant
+- Zustand
 - Tauri
 - Rust
 - Monaco Editor


### PR DESCRIPTION
This PR corrects a typo in the tech stack documentation, changing "Zustant" to "Zustand".